### PR TITLE
intercept page calls

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -71,3 +71,18 @@ SatisMeter.prototype.identify = function(identify) {
 
   window.satismeter(traits);
 };
+
+/**
+ * Page.
+ *
+ * @api public
+ * @param {Page} page
+ */
+
+SatisMeter.prototype.page = function() {
+  window.satismeter({
+    writeKey: this.options.token,
+    userId: this.analytics.user().id(),
+    type: 'page'
+  });
+};

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -126,5 +126,21 @@ describe('SatisMeter', function() {
         });
       });
     });
+
+    describe('#page', function() {
+      beforeEach(function() {
+        analytics.stub(window, 'satismeter');
+      });
+
+      it('should send token and user id', function() {
+        analytics.user().id('id');
+        analytics.page('Pricing');
+        analytics.called(window.satismeter, {
+          writeKey: options.token,
+          userId: 'id',
+          type: 'page'
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
Intercept also `analytics.page` calls so that we can show SatisMeter survey also on pages with no `analytics.identify` call.
