### PR TITLE
support apiKey as a new name for token option

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13,6 +13,7 @@ var when = require('when');
 var SatisMeter = module.exports = integration('SatisMeter')
   .global('satismeter')
   .option('token', '')
+  .option('apiKey', '')
   .tag('<script src="https://app.satismeter.com/satismeter.js">');
 
 /**
@@ -48,7 +49,7 @@ SatisMeter.prototype.loaded = function() {
 
 SatisMeter.prototype.identify = function(identify) {
   var traits = identify.traits();
-  traits.token = this.options.token;
+  traits.token = this.options.apiKey || this.options.token;
   traits.user = {
     id: identify.userId()
   };
@@ -81,7 +82,7 @@ SatisMeter.prototype.identify = function(identify) {
 
 SatisMeter.prototype.page = function() {
   window.satismeter({
-    writeKey: this.options.token,
+    writeKey: this.options.apiKey || this.options.token,
     userId: this.analytics.user().id(),
     type: 'page'
   });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -9,6 +9,147 @@ describe('SatisMeter', function() {
   var analytics;
   var satismeter;
   var options = {
+    apiKey: 'xy1gopRgdl'
+  };
+
+  beforeEach(function() {
+    analytics = new Analytics();
+    satismeter = new SatisMeter(options);
+    analytics.use(SatisMeter);
+    analytics.use(tester);
+    analytics.add(satismeter);
+  });
+
+  afterEach(function() {
+    analytics.restore();
+    analytics.reset();
+    satismeter.reset();
+    sandbox();
+  });
+
+  it('should have the right settings', function() {
+    analytics.compare(SatisMeter, integration('SatisMeter')
+      .global('satismeter')
+      .option('apiKey', ''));
+  });
+
+  describe('before loading', function() {
+    beforeEach(function() {
+      analytics.stub(satismeter, 'load');
+    });
+
+    describe('#initialize', function() {
+      it('should call #load', function() {
+        analytics.initialize();
+        analytics.called(satismeter.load);
+      });
+    });
+  });
+
+  describe('loading', function() {
+    it('should load', function(done) {
+      analytics.load(satismeter, done);
+    });
+  });
+
+  describe('after loading', function() {
+    beforeEach(function(done) {
+      analytics.once('ready', done);
+      analytics.initialize();
+    });
+
+    describe('#identify', function() {
+      beforeEach(function() {
+        analytics.stub(window, 'satismeter');
+      });
+
+      it('should send apiKey and user id', function() {
+        analytics.identify('id');
+        analytics.called(window.satismeter, {
+          token: options.apiKey,
+          user: {
+            id: 'id'
+          }
+        });
+      });
+
+      it('should send email', function() {
+        analytics.identify('id', { email: 'email@example.com' });
+        analytics.called(window.satismeter, {
+          token: options.apiKey,
+          user: {
+            id: 'id',
+            email: 'email@example.com'
+          }
+        });
+      });
+
+      it('should send user name', function() {
+        analytics.identify('id', { name: 'john doe' });
+        analytics.called(window.satismeter, {
+          token: options.apiKey,
+          user: {
+            id: 'id',
+            name: 'john doe'
+          }
+        });
+      });
+
+      it('should send signUpDate', function() {
+        var now = new Date();
+        analytics.identify('id', { created: now });
+        analytics.called(window.satismeter, {
+          token: options.apiKey,
+          user: {
+            id: 'id',
+            signUpDate: now.toISOString()
+          }
+        });
+      });
+
+      it('should send custom traits', function() {
+        analytics.identify('id', {
+          translation: {
+            FOLLOWUP: 'What can we improve'
+          },
+          language: 'en'
+        });
+        analytics.called(window.satismeter, {
+          token: options.apiKey,
+          user: {
+            id: 'id'
+          },
+          translation: {
+            FOLLOWUP: 'What can we improve'
+          },
+          language: 'en'
+        });
+      });
+    });
+
+    describe('#page', function() {
+      beforeEach(function() {
+        analytics.stub(window, 'satismeter');
+      });
+
+      it('should send apiKey and user id', function() {
+        analytics.user().id('id');
+        analytics.page('Pricing');
+        analytics.called(window.satismeter, {
+          writeKey: options.apiKey,
+          userId: 'id',
+          type: 'page'
+        });
+      });
+    });
+  });
+});
+
+describe('SatisMeter - legacy setup', function() {
+  // to be removed once we complete the renaming from token to apiKey
+  var analytics;
+  var satismeter;
+  var options = {
     token: 'xy1gopRgdl'
   };
 


### PR DESCRIPTION
The `token` option is being renamed to `apiKey` so that we can have one for both client-side and server-side integrations.

In the first phase we support both `apiKey` and `token` interchangeably.
