### PR TITLE
Identifying source of identify/page request

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -7,7 +7,7 @@ module.exports = function(config) {
       'test/**/*.test.js'
     ],
 
-    browsers: ['PhantomJS'],
+    browsers: ['Chrome'],
 
     frameworks: ['browserify', 'mocha'],
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -53,7 +53,8 @@ SatisMeter.prototype.identify = function(identify) {
     writeKey: this.options.apiKey || this.options.token,
     userId: identify.userId(),
     traits: this.analytics.user().traits(),
-    type: 'identify'
+    type: 'identify',
+    source: 'analytics.js'
   });
 };
 
@@ -68,6 +69,7 @@ SatisMeter.prototype.page = function() {
   window.satismeter({
     writeKey: this.options.apiKey || this.options.token,
     userId: this.analytics.user().id(),
-    type: 'page'
+    type: 'page',
+    source: 'analytics.js'
   });
 };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -64,14 +64,15 @@ describe('SatisMeter', function() {
         analytics.stub(window, 'satismeter');
       });
 
-      it('should send apiKey and user id', function() {
+      it('should send apiKey, user id and source', function() {
         analytics.identify('id');
         analytics.called(window.satismeter, {
           writeKey: options.apiKey,
           userId: 'id',
           traits: {
           },
-          type: 'identify'
+          type: 'identify',
+          source: 'analytics.js'
         });
       });
 
@@ -83,7 +84,8 @@ describe('SatisMeter', function() {
           traits: {
             email: 'email@example.com'
           },
-          type: 'identify'
+          type: 'identify',
+          source: 'analytics.js'
         });
       });
 
@@ -95,7 +97,8 @@ describe('SatisMeter', function() {
           traits: {
             name: 'john doe'
           },
-          type: 'identify'
+          type: 'identify',
+          source: 'analytics.js'
         });
       });
 
@@ -108,7 +111,8 @@ describe('SatisMeter', function() {
           traits: {
             createdAt: now
           },
-          type: 'identify'
+          type: 'identify',
+          source: 'analytics.js'
         });
       });
 
@@ -128,7 +132,8 @@ describe('SatisMeter', function() {
             },
             language: 'en'
           },
-          type: 'identify'
+          type: 'identify',
+          source: 'analytics.js'
         });
       });
     });
@@ -138,13 +143,14 @@ describe('SatisMeter', function() {
         analytics.stub(window, 'satismeter');
       });
 
-      it('should send apiKey and user id', function() {
+      it('should send apiKey, user id and source', function() {
         analytics.user().id('id');
         analytics.page('Pricing');
         analytics.called(window.satismeter, {
           writeKey: options.apiKey,
           userId: 'id',
-          type: 'page'
+          type: 'page',
+          source: 'analytics.js'
         });
       });
     });
@@ -210,14 +216,15 @@ describe('SatisMeter - legacy setup', function() {
         analytics.stub(window, 'satismeter');
       });
 
-      it('should send token and user id', function() {
+      it('should send token, user id and source', function() {
         analytics.identify('id');
         analytics.called(window.satismeter, {
           writeKey: options.token,
           userId: 'id',
           traits: {
           },
-          type: 'identify'
+          type: 'identify',
+          source: 'analytics.js'
         });
       });
 
@@ -229,7 +236,8 @@ describe('SatisMeter - legacy setup', function() {
           traits: {
             email: 'email@example.com'
           },
-          type: 'identify'
+          type: 'identify',
+          source: 'analytics.js'
         });
       });
 
@@ -241,7 +249,8 @@ describe('SatisMeter - legacy setup', function() {
           traits: {
             name: 'john doe'
           },
-          type: 'identify'
+          type: 'identify',
+          source: 'analytics.js'
         });
       });
 
@@ -254,7 +263,8 @@ describe('SatisMeter - legacy setup', function() {
           traits: {
             createdAt: now
           },
-          type: 'identify'
+          type: 'identify',
+          source: 'analytics.js'
         });
       });
 
@@ -274,7 +284,8 @@ describe('SatisMeter - legacy setup', function() {
             },
             language: 'en'
           },
-          type: 'identify'
+          type: 'identify',
+          source: 'analytics.js'
         });
       });
     });
@@ -284,13 +295,14 @@ describe('SatisMeter - legacy setup', function() {
         analytics.stub(window, 'satismeter');
       });
 
-      it('should send token and user id', function() {
+      it('should send token, user id and source', function() {
         analytics.user().id('id');
         analytics.page('Pricing');
         analytics.called(window.satismeter, {
           writeKey: options.token,
           userId: 'id',
-          type: 'page'
+          type: 'page',
+          source: 'analytics.js'
         });
       });
     });


### PR DESCRIPTION
Hi, I'm Alberto from SatisMeter.

We need to be able to identify where the request for `identify` and `page` came from, in order to know if it came from `analytics.js` or other source.

Also I switched from PhantomJs to Chrome in `karma.conf`. PhantomJs lacks support for ES6 Promises and it's development has been suspended until further notice (see ariya/phantomjs#15344).